### PR TITLE
Add support for <body> tags. Closes #1.

### DIFF
--- a/lib/domify.js
+++ b/lib/domify.js
@@ -28,6 +28,15 @@ var map = {
 module.exports = function(html){
   html = String(html);
   var tag = /<([\w:]+)/.exec(html)[1];
+
+  if (tag === 'body') {
+    var childrenHtml = html.replace(/^\s*<body[^>]*>/, '')
+                           .replace(/<\/body>\s*$/, '');
+    var bodyEl = document.createElement('body');
+    bodyEl.innerHTML = childrenHtml;
+    return bodyEl;
+  }
+
   var wrap = map[tag] || map._default;
   var depth = wrap[0];
   var prefix = wrap[1];


### PR DESCRIPTION
Got the tests running by changing `module.exports =` to `window.domify =` and `require('domify')` to `window.domify`, so I was indeed able to verify everything passes.

Woo!
