### PR TITLE
Throw an error if more than one element is generated.

### DIFF
--- a/lib/domify.js
+++ b/lib/domify.js
@@ -27,7 +27,13 @@ var map = {
 
 module.exports = function(html){
   html = String(html);
-  var tag = /<([\w:]+)/.exec(html)[1];
+  var tagMatch = /<([\w:]+)/.exec(html);
+
+  if (!tagMatch) {
+    throw new Error('No elements were generated.');
+  }
+
+  var tag = tagMatch[1];
 
   if (tag == 'body') {
     html = html.replace(/^\s*<body[^>]*>/, '').replace(/<\/body>\s*$/, '');
@@ -44,7 +50,7 @@ module.exports = function(html){
   el.innerHTML = prefix + html + suffix;
   while (depth--) el = el.lastChild;
 
-  if (el.lastChild.nextElementSibling || el.lastChild.previousElementSibling){
+  if (el.lastChild.nextElementSibling || el.lastChild.previousElementSibling) {
     throw new Error('More than one element was generated.');
   }
 

--- a/test/domify.js
+++ b/test/domify.js
@@ -78,4 +78,15 @@ describe('domify(html)', function(){
 
     assert(thrown && /more than one element/i.test(thrown.message));
   })
+
+  it('should throw if no tag is given', function(){
+    var thrown = null;
+    try {
+      domify('  ');
+    } catch (err) {
+      thrown = err;
+    }
+
+    assert(thrown && /no elements/i.test(thrown.message));
+  })
 })


### PR DESCRIPTION
We could also hide this behind a flag, e.g. `domify('...', { strict: true })` or `domify.strict = true`.
