### PR TITLE
Remove dummy parent div from generated elements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function(html){
     throw new Error('More than one element was generated.');
   }
 
-  return el.lastChild;
+  return el.removeChild(el.lastChild);
 };
 
 /**

--- a/test/domify.js
+++ b/test/domify.js
@@ -89,4 +89,9 @@ describe('domify(html)', function(){
 
     assert(thrown && /no elements/i.test(thrown.message));
   })
+  it('should not set parentElement', function() {
+    var el = domify('<p>Hello</p>');
+    assert(!el.parentElement);
+    assert(!el.parentNode);
+  })
 })


### PR DESCRIPTION
Currently, generated nodes have a parent div element. 

``` js
var el = domify('<p></p>')
console.log(el.parentNode) // => <div></div>
```

This isn't an issue once the child is in the dom, as the child gets a new parent, but if you're manipulating the child before injecting into the dom, the unsolicited parent can lead to issues, and shouldn't be there as far as I can tell.

This patch removes the parent from the child before returning it.
