### PR TITLE
Support generation of body elements with attributes (e.g. class)

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ module.exports = function(html){
 
   // body support
   if (tag == 'body') {
-    var el = document.createElement('body');
-    el.innerHTML = stripBody(html);
-    return el;
+    var el = document.createElement('html');
+    el.innerHTML = html;
+    return el.removeChild(el.lastChild);
   }
 
   // wrap map
@@ -55,15 +55,3 @@ module.exports = function(html){
 
   return el.lastChild;
 };
-
-/**
- * Strip body tags from `html`.
- *
- * @param {String} html
- * @return {String}
- * @api private
- */
-
-function stripBody(html) {
-  return html.replace(/^\s*<body[^>]*>/, '').replace(/<\/body>\s*$/, '');
-}

--- a/test/domify.js
+++ b/test/domify.js
@@ -8,6 +8,17 @@ describe('domify(html)', function(){
     assert('Hello' == el.textContent);
   })
 
+  it('should support body tags', function(){
+    var el = domify('<body></body>');
+    assert('BODY' == el.nodeName);
+  })
+
+  it('should support body tags with classes', function(){
+    var el = domify('<body class="page"></body>');
+    assert('BODY' == el.nodeName);
+    assert('page' == el.className);
+  })
+
   it('should support legend tags', function(){
     var el = domify('<legend>Hello</legend>');
     assert('LEGEND' == el.nodeName);


### PR DESCRIPTION
I don't understand the purpose of the `stripBody` [function](https://github.com/component/domify/blob/44b94967a1a5329ffe2025d8efa4a3d00e08d7ee/index.js#L67). Is it something to do with cross-browser compatibility? I have tested recent chrome/firefox/safari, but have no IE to test (same goes for the other PRs in fact :( ).

Anyway,  `domify('<body class="page"></body>')` loses the class. This patch fixes that.
