### PR TITLE
Tolerate leading/trailing whitespace in html string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ var map = {
 
 module.exports = function(html){
   if ('string' != typeof html) throw new TypeError('String expected');
+  html = html.trim()
 
   // tag name
   var m = /<([\w:]+)/.exec(html);

--- a/test/domify.js
+++ b/test/domify.js
@@ -19,6 +19,12 @@ describe('domify(html)', function(){
     assert('page' == el.className);
   })
 
+  it('should ignore trailing/leading whitespace', function(){
+    var el = domify(' <p>Hello</p> ');
+    assert('P' == el.nodeName);
+    assert('Hello' == el.textContent);
+  })
+
   it('should support legend tags', function(){
     var el = domify('<legend>Hello</legend>');
     assert('LEGEND' == el.nodeName);


### PR DESCRIPTION
Fixes bug where can't `domify` component-converted templates correctly without `.trim` due to trailing newline in template files. 

I can't think of any use case where you'd want domify to care about leading/trailing whitespace.
