### PR TITLE
use document fragment for multiple top level elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function parse(html) {
   if (tag == 'body') {
     var el = document.createElement('html');
     el.innerHTML = html;
-    return [el.removeChild(el.lastChild)];
+    return el.removeChild(el.lastChild);
   }
   
   // wrap map
@@ -57,23 +57,15 @@ function parse(html) {
   el.innerHTML = prefix + html + suffix;
   while (depth--) el = el.lastChild;
 
-  return orphan(el.children);
-}
-
-/**
- * Orphan `els` and return an array.
- *
- * @param {NodeList} els
- * @return {Array}
- * @api private
- */
-
-function orphan(els) {
-  var ret = [];
-
-  while (els.length) {
-    ret.push(els[0].parentNode.removeChild(els[0]));
+  var els = el.children;
+  if (els.length === 1) {
+    return el.removeChild(els[0]);
   }
 
-  return ret;
+  var fragment = document.createDocumentFragment();
+  while (els.length) {
+    fragment.appendChild(el.removeChild(els[0]));
+  }
+
+  return fragment;
 }

--- a/test/domify.js
+++ b/test/domify.js
@@ -1,91 +1,90 @@
 
-var domify = require('domify');
+var assert = require('assert');
+var domify = require('../');
 
 describe('domify(html)', function(){
   it('should convert HTML to DOM elements', function(){
-    var el = domify('<p>Hello</p>')[0];
+    var el = domify('<p>Hello</p>');
     assert('P' == el.nodeName);
     assert('Hello' == el.textContent);
 
     var els = domify('<p>one</p><p>two</p><p>three</p>');
-    assert('one' == els[0].textContent);
-    assert('two' == els[1].textContent);
-    assert('three' == els[2].textContent);
+    assert('onetwothree' == els.textContent);
   })
 
   it('should support body tags', function(){
-    var el = domify('<body></body>')[0];
+    var el = domify('<body></body>');
     assert('BODY' == el.nodeName);
   })
 
   it('should support body tags with classes', function(){
-    var el = domify('<body class="page"></body>')[0];
+    var el = domify('<body class="page"></body>');
     assert('BODY' == el.nodeName);
     assert('page' == el.className);
   })
 
   it('should support legend tags', function(){
-    var el = domify('<legend>Hello</legend>')[0];
+    var el = domify('<legend>Hello</legend>');
     assert('LEGEND' == el.nodeName);
   })
 
   it('should support table tags', function(){
-    var el = domify('<table></table>')[0];
+    var el = domify('<table></table>');
     assert('TABLE' == el.nodeName);
   })
 
   it('should support thead tags', function(){
-    var el = domify('<thead></thead>')[0];
+    var el = domify('<thead></thead>');
     assert('THEAD' == el.nodeName);
   })
 
   it('should support tbody tags', function(){
-    var el = domify('<tbody></tbody>')[0];
+    var el = domify('<tbody></tbody>');
     assert('TBODY' == el.nodeName);
   })
 
   it('should support tfoot tags', function(){
-    var el = domify('<tfoot></tfoot>')[0];
+    var el = domify('<tfoot></tfoot>');
     assert('TFOOT' == el.nodeName);
   })
 
   it('should support caption tags', function(){
-    var el = domify('<caption></caption>')[0];
+    var el = domify('<caption></caption>');
     assert('CAPTION' == el.nodeName);
   })
 
   it('should support col tags', function(){
-    var el = domify('<col></col>')[0];
+    var el = domify('<col></col>');
     assert('COL' == el.nodeName);
   })
 
   it('should support td tags', function(){
-    var el = domify('<td></td>')[0];
+    var el = domify('<td></td>');
     assert('TD' == el.nodeName);
   })
 
   it('should support th tags', function(){
-    var el = domify('<th></th>')[0];
+    var el = domify('<th></th>');
     assert('TH' == el.nodeName);
   })
 
   it('should support tr tags', function(){
-    var el = domify('<tr></tr>')[0];
+    var el = domify('<tr></tr>');
     assert('TR' == el.nodeName);
   })
 
   it('should support option tags', function(){
-    var el = domify('<option></option>')[0];
+    var el = domify('<option></option>');
     assert('OPTION' == el.nodeName);
   })
 
   it('should support optgroup tags', function(){
-    var el = domify('<optgroup></optgroup>')[0];
+    var el = domify('<optgroup></optgroup>');
     assert('OPTGROUP' == el.nodeName);
   })
 
   it('should not set parentElement', function() {
-    var el = domify('<p>Hello</p>')[0];
+    var el = domify('<p>Hello</p>');
     assert(!el.parentElement);
     assert(!el.parentNode);
   })


### PR DESCRIPTION
When a string of multiple top level nodes is present, create a document
fragment to contain them.

`<p>foo</p><p>bar</p>` will result in a document fragment
