### PR TITLE
Tolerate leading/trailing whitespace in html string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ var map = {
 function parse(html) {
   if ('string' != typeof html) throw new TypeError('String expected');
 
+  html = html.replace(/^\s+|\s+$/g, ''); // Remove leading/trailing whitespace
+
   // tag name
   var m = /<([\w:]+)/.exec(html);
   if (!m) throw new Error('No elements were generated.');

--- a/test/domify.js
+++ b/test/domify.js
@@ -12,6 +12,12 @@ describe('domify(html)', function(){
     assert('onetwothree' == els.textContent);
   })
 
+  it('should ignore trailing/leading whitespace', function(){
+    var el = domify(' <p>Hello</p> ');
+    assert('P' == el.nodeName);
+    assert('Hello' == el.textContent);
+  })
+
   it('should support body tags', function(){
     var el = domify('<body></body>');
     assert('BODY' == el.nodeName);


### PR DESCRIPTION
Fixes bug where can't domify component-converted templates correctly without .trim due to trailing newline in template files.

I can't think of any use case where you'd want domify to care about leading/trailing whitespace.
