### PR TITLE
Allow other implementations of `document`

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ if (typeof document !== 'undefined') {
   bugTestDiv.innerHTML = '  <link/><table></table><a href="/a">a</a><input type="checkbox"/>';
   // Make sure that link elements get serialized correctly by innerHTML
   // This requires a wrapper element in IE
-  var innerHTMLBug = !bugTestDiv.getElementsByTagName('link').length;
+  innerHTMLBug = !bugTestDiv.getElementsByTagName('link').length;
   bugTestDiv = undefined;
 }
 

--- a/index.js
+++ b/index.js
@@ -9,13 +9,17 @@ module.exports = parse;
  * Tests for browser support.
  */
 
-var div = document.createElement('div');
-// Setup
-div.innerHTML = '  <link/><table></table><a href="/a">a</a><input type="checkbox"/>';
-// Make sure that link elements get serialized correctly by innerHTML
-// This requires a wrapper element in IE
-var innerHTMLBug = !div.getElementsByTagName('link').length;
-div = undefined;
+var innerHTMLBug = false;
+var bugTestDiv;
+if (typeof document !== 'undefined') {
+  bugTestDiv = document.createElement('div');
+  // Setup
+  bugTestDiv.innerHTML = '  <link/><table></table><a href="/a">a</a><input type="checkbox"/>';
+  // Make sure that link elements get serialized correctly by innerHTML
+  // This requires a wrapper element in IE
+  var innerHTMLBug = !bugTestDiv.getElementsByTagName('link').length;
+  bugTestDiv = undefined;
+}
 
 /**
  * Wrap map from jquery.


### PR DESCRIPTION
The check only makes sense in a browser environment anyway.