### PR TITLE
Fix XSS via prototype pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function parse(html, doc) {
   }
 
   // wrap map
-  var wrap = map[tag] || map._default;
+  var wrap = map.hasOwnProperty(tag) ? map[tag] : map._default;
   var depth = wrap[0];
   var prefix = wrap[1];
   var suffix = wrap[2];

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function parse(html, doc) {
   }
 
   // wrap map
-  var wrap = map.hasOwnProperty(tag) ? map[tag] : map._default;
+  var wrap = Object.prototype.hasOwnProperty.call(map, tag) ? map[tag] : map._default;
   var depth = wrap[0];
   var prefix = wrap[1];
   var suffix = wrap[2];


### PR DESCRIPTION
This PR fixes a a breach for XSS via prototype pollution

`map[tag] || map._default` checks if the `map` object has a property `tag`, and if not goes up the prototype chain to check if the tag is part of the parent object. In this case, since the Object is polluted (because one can paste, for example, in the terminal, code such as `Object.prototype.script = [1,'<img/src/onerror=alert(1)>','<img/src/onerror=alert(2)>']
`), the tag exists, and the code picks the bad value.

`map.hasOwnProperty(tag) ? ...` checks if the map object has the `tag` property, but doesn’t go up the prototype check to see if tag is inherited from a parent object.

Before:

https://user-images.githubusercontent.com/484013/116165943-c0dc0900-a6b1-11eb-924e-a37ea6d22acc.mov


After:

https://user-images.githubusercontent.com/484013/116165949-c76a8080-a6b1-11eb-8e99-0b157f75dd59.mov

